### PR TITLE
bump go version for compatibility tests on 1.24

### DIFF
--- a/config/prow/release-branch-jobs/1.24.yaml
+++ b/config/prow/release-branch-jobs/1.24.yaml
@@ -747,7 +747,7 @@ presubmits:
         - runner.sh
         env:
         - name: GO_VERSION
-          value: 1.18.1
+          value: 1.19.1
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-1.24
         name: ""
         resources:
@@ -805,7 +805,7 @@ presubmits:
         - test
         env:
         - name: GO_VERSION
-          value: 1.18.1
+          value: 1.19.1
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-1.24
         name: ""
         resources:


### PR DESCRIPTION
bump go version from 1.18 to 1.19 for go-compatibility tests on 1.24