### PR TITLE
Update PROW and KUBEKINS-E2E image tags

### DIFF
--- a/.github/workflows/deploy-lts-prow.yaml
+++ b/.github/workflows/deploy-lts-prow.yaml
@@ -16,8 +16,8 @@ jobs:
       GITHUB_REPO: ${{ vars.REPO }}
       HMAC_TOKEN: ${{ secrets.HMAC_TOKEN }}
       MINIO_CONSOLE_PORT: 8003
-      K8S_PROW_IMAGE_TAG: v20230714-b138fd6e05
-      KUBEKINS_E2E_TAG: v20230703-e6ae5b372a-master
+      K8S_PROW_IMAGE_TAG: v20240723-dbbd2d86b
+      KUBEKINS_E2E_TAG: v20240705-131cd74733-master #might be unused
     steps:
       - name: Generate fake mount secret
         run: |

--- a/.github/workflows/deploy-lts-prow.yaml
+++ b/.github/workflows/deploy-lts-prow.yaml
@@ -17,7 +17,6 @@ jobs:
       HMAC_TOKEN: ${{ secrets.HMAC_TOKEN }}
       MINIO_CONSOLE_PORT: 8003
       K8S_PROW_IMAGE_TAG: v20240723-dbbd2d86b
-      KUBEKINS_E2E_TAG: v20240705-131cd74733-master #might be unused
     steps:
       - name: Generate fake mount secret
         run: |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,3 @@ LTS specific configuration and tooling for testing
 Image repo: https://console.cloud.google.com/gcr/images/k8s-prow
 
 Reference the version used in upstream by looking up [gcr.io/k8s-prow/prow-controller-manager](https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+gcr.io%2Fk8s-prow%2Fprow-controller-manager&type=code) or [gcr.io/k8s-prow/entrypoint](https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+gcr.io%2Fk8s-prow%2Fentrypoint&type=code) verions.
-
-## KUBEKINS-E2E (KUBEKINS_E2E_TAG)
-Reference the version used in upstraem by looking up [kubekins-e2e:](https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+kubekins-e2e%3A&type=code&p=2)

--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ LTS specific configuration and tooling for testing
       Check if the tests run and succeed.
     - If tests don't run or fail, check https://aka.ms/aks/prow. Some of them might need additional tweaking, e.g. request less CPU/memory 
     - Once all is looking good, remember to merge the PR on this repo.
+
+# Updating image tags
+## PROW (K8S_PROW_IMAGE_TAG)
+Image repo: https://console.cloud.google.com/gcr/images/k8s-prow
+
+Reference the version used in upstream by looking up [gcr.io/k8s-prow/prow-controller-manager](https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+gcr.io%2Fk8s-prow%2Fprow-controller-manager&type=code) or [gcr.io/k8s-prow/entrypoint](https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+gcr.io%2Fk8s-prow%2Fentrypoint&type=code) verions.
+
+## KUBEKINS-E2E (KUBEKINS_E2E_TAG)
+Reference the version used in upstraem by looking up [kubekins-e2e:](https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+kubekins-e2e%3A&type=code&p=2)


### PR DESCRIPTION
Update PROW and KUBEKINS-E2E image tags. The existing tags might be obsolete as they are over one year old.