### PR TITLE
Add 2 prow jobs for 1.27

### DIFF
--- a/config/prow/release-branch-jobs/1.27.yaml
+++ b/config/prow/release-branch-jobs/1.27.yaml
@@ -115,3 +115,59 @@
               memory: 4Gi
       securityContext:
         runAsUser: 2000
+  - always_run: true
+    branches:
+    - release-1.27-lts
+    context: pull-kubernetes-typecheck
+    decorate: true
+    name: pull-kubernetes-typecheck
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - verify
+        command:
+        - make
+        env:
+        - name: WHAT
+          value: typecheck typecheck-providerless
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.27
+        name: main
+        resources:
+          limits:
+            cpu: "5"
+            memory: 32Gi
+          requests:
+            cpu: "5"
+            memory: 32Gi
+  - always_run: true
+    branches:
+    - release-1.27-lts
+    context: pull-kubernetes-unit-go-compatibility
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        env:
+        - name: GO_VERSION
+          value: 1.20.2
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.27
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 36Gi
+          requests:
+            cpu: "4"
+            memory: 36Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsGroup: 2010
+        runAsUser: 2001


### PR DESCRIPTION
Add prow job pull-kubernetes-typecheck
https://aksltsprow-b8bqh2ewcgeecjav.b01.azurefd.net/view/s3/prow-logs/pr-logs/pull/aks-lts_kubernetes/26/pull-kubernetes-typecheck/1816179846754078720

Add prow job pull-kubernetes-unit-go-compatibility
https://aksltsprow-b8bqh2ewcgeecjav.b01.azurefd.net/view/s3/prow-logs/pr-logs/pull/aks-lts_kubernetes/26/pull-kubernetes-unit-go-compatibility/1816192631588261888