### PR TITLE
Add 1.29 LTS release jobs

### DIFF
--- a/.github/workflows/deploy-lts-prow.yaml
+++ b/.github/workflows/deploy-lts-prow.yaml
@@ -128,6 +128,7 @@ jobs:
           envsubst < config/prow/release-branch-jobs/base.yaml > cm.yaml
           envsubst < config/prow/release-branch-jobs/1.27.yaml >> cm.yaml
           envsubst < config/prow/release-branch-jobs/1.28.yaml >> cm.yaml
+          envsubst < config/prow/release-branch-jobs/1.29.yaml >> cm.yaml
           kubectl create configmap config -n prow --from-file=config.yaml=cm.yaml -o yaml --dry-run=client | kubectl apply -f -
           rm cm.yaml
         env:

--- a/config/prow/release-branch-jobs/1.29.yaml
+++ b/config/prow/release-branch-jobs/1.29.yaml
@@ -1,0 +1,439 @@
+# 1.29-lts jobs, do not change indentation of the lines below, it need to be aligned with base.yaml
+# Based on config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+  - always_run: false
+    branches:
+    - release-1.29-lts
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-conformance-kind-ipv6-parallel
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+    max_concurrency: 8
+    name: pull-kubernetes-conformance-kind-ipv6-parallel
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: ^test/
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: IP_FAMILY
+          value: ipv6
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20250227-3a13bdd784-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.29-lts-lts
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-dependencies
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-dependencies
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - make
+        - verify
+        command:
+        - runner.sh
+        env:
+        - name: WHAT
+          value: external-dependencies-version vendor vendor-licenses
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.29
+        name: main
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1288490188800m
+          requests:
+            cpu: "2"
+            memory: 1288490188800m
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    context: pull-kubernetes-integration
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-dockerized.sh
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 15Gi
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    context: pull-kubernetes-integration-go-compatibility
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: GO_VERSION
+          value: 1.21.4
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 15Gi
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    name: pull-kubernetes-e2e-kind
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FOCUS
+          value: .
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20250227-3a13bdd784-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-ipv6
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    name: pull-kubernetes-e2e-kind-ipv6
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FOCUS
+          value: .
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
+        - name: PARALLEL
+          value: "true"
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: IP_FAMILY
+          value: ipv6
+        image: gcr.io/k8s-staging-test-infra/krte:v20250227-3a13bdd784-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9Gi
+          requests:
+            cpu: "4"
+            memory: 9Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-conformance-kind-ga-only-parallel
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    name: pull-kubernetes-conformance-kind-ga-only-parallel
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: GA_ONLY
+          value: "true"
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20250227-3a13bdd784-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9Gi
+          requests:
+            cpu: "4"
+            memory: 9Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-unit
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 36Gi
+          requests:
+            cpu: "4"
+            memory: 36Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsGroup: 2010
+        runAsUser: 2001
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-unit-go-compatibility
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        env:
+        - name: GO_VERSION
+          value: 1.21.4
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 36Gi
+          requests:
+            cpu: "4"
+            memory: 36Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsGroup: 2010
+        runAsUser: 2001
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    context: pull-kubernetes-typecheck
+    decorate: true
+    name: pull-kubernetes-typecheck
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - verify
+        command:
+        - make
+        env:
+        - name: WHAT
+          value: typecheck typecheck-providerless
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.29
+        name: main
+        resources:
+          limits:
+            cpu: "5"
+            memory: 32Gi
+          requests:
+            cpu: "5"
+            memory: 32Gi
+  - always_run: false
+    branches:
+    - release-1.29-lts
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-update
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-update
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/update-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: EXCLUDE_TYPECHECK
+          value: "y"
+        - name: EXCLUDE_GODEP
+          value: "y"
+        - name: KUBE_VERIFY_GIT_BRANCH
+          value: release-1.29-lts
+        - name: REPO_DIR
+          value: /workspace/k8s.io/kubernetes
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.29
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 12Gi
+          requests:
+            cpu: "7"
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    context: pull-kubernetes-verify
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-verify
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/verify-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: EXCLUDE_TYPECHECK
+          value: "y"
+        - name: EXCLUDE_GODEP
+          value: "y"
+        - name: KUBE_VERIFY_GIT_BRANCH
+          value: release-1.29-lts
+        - name: REPO_DIR
+          value: /workspace/k8s.io/kubernetes
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.29
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 12Gi
+          requests:
+            cpu: "7"
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.29-lts
+    context: pull-kubernetes-linter-hints
+    decorate: true
+    name: pull-kubernetes-linter-hints
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - verify
+        - WHAT=golangci-lint-pr-hints
+        command:
+        - make
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 12Gi
+          requests:
+            cpu: "5"
+            memory: 12Gi

--- a/config/prow/release-branch-jobs/1.29.yaml
+++ b/config/prow/release-branch-jobs/1.29.yaml
@@ -399,10 +399,10 @@
         resources:
           limits:
             cpu: "7"
-            memory: 12Gi
+            memory: 16Gi
           requests:
             cpu: "7"
-            memory: 12Gi
+            memory: 16Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -425,7 +425,7 @@
         resources:
           limits:
             cpu: "5"
-            memory: 12Gi
+            memory: 16Gi
           requests:
             cpu: "5"
-            memory: 12Gi
+            memory: 16Gi

--- a/config/prow/release-branch-jobs/1.29.yaml
+++ b/config/prow/release-branch-jobs/1.29.yaml
@@ -3,7 +3,6 @@
   - always_run: false
     branches:
     - release-1.29-lts
-    cluster: k8s-infra-prow-build
     context: pull-kubernetes-conformance-kind-ipv6-parallel
     decorate: true
     labels:
@@ -43,7 +42,6 @@
   - always_run: true
     branches:
     - release-1.29-lts-lts
-    cluster: k8s-infra-prow-build
     context: pull-kubernetes-dependencies
     decorate: true
     labels:
@@ -134,7 +132,6 @@
   - always_run: true
     branches:
     - release-1.29-lts
-    cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-kind
     decorate: true
     decoration_config:
@@ -173,7 +170,6 @@
   - always_run: true
     branches:
     - release-1.29-lts
-    cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-kind-ipv6
     decorate: true
     decoration_config:
@@ -216,7 +212,6 @@
   - always_run: true
     branches:
     - release-1.29-lts
-    cluster: k8s-infra-prow-build
     context: pull-kubernetes-conformance-kind-ga-only-parallel
     decorate: true
     decoration_config:
@@ -253,7 +248,6 @@
   - always_run: true
     branches:
     - release-1.29-lts
-    cluster: k8s-infra-prow-build
     context: pull-kubernetes-unit
     decorate: true
     labels:
@@ -282,7 +276,6 @@
   - always_run: true
     branches:
     - release-1.29-lts
-    cluster: k8s-infra-prow-build
     context: pull-kubernetes-unit-go-compatibility
     decorate: true
     labels:
@@ -341,7 +334,6 @@
   - always_run: false
     branches:
     - release-1.29-lts
-    cluster: k8s-infra-prow-build
     context: pull-kubernetes-update
     decorate: true
     labels:

--- a/config/prow/release-branch-jobs/base.yaml
+++ b/config/prow/release-branch-jobs/base.yaml
@@ -27,11 +27,7 @@ deck:
           - podinfo.json
   rerun_auth_configs:
     '*':
-      # You can look up its ID using this command, where the team slug is the hyphenated name:
-	    # curl -H "Authorization: token <token>" "https://api.github.com/orgs/<org-name>/teams/<team slug>"
-      # ref: https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#list-teams
-      github_team_ids:
-      - 13038351 # aks-lts-maintain
+      allow_anyone: true
 
 plank:
   job_url_prefix_config:

--- a/config/prow/release-branch-jobs/base.yaml
+++ b/config/prow/release-branch-jobs/base.yaml
@@ -25,9 +25,6 @@ deck:
           name: podinfo
         required_files:
           - podinfo.json
-  rerun_auth_configs:
-    '*':
-      allow_anyone: true
 
 plank:
   job_url_prefix_config:

--- a/config/prow/release-branch-jobs/base.yaml
+++ b/config/prow/release-branch-jobs/base.yaml
@@ -25,6 +25,13 @@ deck:
           name: podinfo
         required_files:
           - podinfo.json
+  rerun_auth_configs:
+    '*':
+      # You can look up its ID using this command, where the team slug is the hyphenated name:
+	    # curl -H "Authorization: token <token>" "https://api.github.com/orgs/<org-name>/teams/<team slug>"
+      # ref: https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#list-teams
+      github_team_ids:
+      - 13038351 # aks-lts-maintain
 
 plank:
   job_url_prefix_config:


### PR DESCRIPTION
Add PROW release job for 1.29 LTS branch.
Difference from upstream/[release-branch-jobs/1.29.yaml](https://github.com/kubernetes/test-infra/blob/8e76d3974935165c51914edc8ec89ba79cd68c05/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml#L547):
-  Expand the memory for golangci-lint tests from 14Gi to 16Gi to prevent OOMKill on the test pod.